### PR TITLE
Update command-pattern-with-autowirelocator.md - Round #1

### DIFF
--- a/sfcasts/command-pattern-with-autowirelocator.md
+++ b/sfcasts/command-pattern-with-autowirelocator.md
@@ -1,67 +1,29 @@
-# Command Pattern with AutowireLocator
+# Command Pattern with `#[AutowireLocator]`
 
-Okay, let's get started. So looking at our app, this is our remote UI. It’s basically just a form, and each button
-on the submits the form. Each button's `name` attribute is unique so our controller can determine which
-button logic to execute. So you can see when we click the power button here, we see this flash message. This is added by the
-controller and tells us what happened. For example, the power button was pressed, then channel up was pressed, and channel
-down was pressed.
+Let's *do this*! If we take a look at our app, *this* is the UI for our remote. It’s basically just a form, and each button *submits* the form. The `name` attribute for each button is unique, and that helps our controller determine which button's logic to execute. When we click the "Power" button, for example, we see this flash message (added by the controller) that tells us what happened. If we press "Channel Up", "Channel Down", and so on, we see the same corresponding messages.
 
-This form just posts to the same page, handles the button logic, and then redirects us back with the flash message. We can
-look in the profiler to see what that post request looked like by clicking here. You can see the last button we pressed was
-the channel down button. Each button has a `dump()` message that we're using to represent the _button logic_.
+So this is *super* simple. The form just posts to the same page, handles the button logic, and then redirects us back with the flash message. If we click here, we can hop into in the profiler to see the `POST` request. This message is a `dump()` we're using to represent the button logic, and *this* one tells us that the last button we clicked was the "Channel Down" button. That checks out!
 
-We can go into `src/Controller`, find the `RemoteController`, and here we go. We’re checking if the request is a `POST`, and
-then we have a switch statement where we grab the button name from the request. Each button submits with a name, and we
-handle this for each button with a case for power, channel up, etc. These `dump()`'s represent the logic for each
-button. If we can’t find the button, we throw a 404 with a little message. Then we add the flash message, doing a bit of
-string manipulation to make the button name look nicer, and redirect right back to the same route.
+Over in our code, open up `src/Controller`, find the `RemoteController` and... here we go! We’re checking to see if the request is a `POST`, and since each button *submits* with a name, this `switch()` statement grabs that from the request. Each button is wrapped in a `case`, and each `dump()` represents the button's individual logic. If a button *isn't* found, this will throw a 404. *Then* we add the flash message, do a bit of string manipulation to make the button name look nicer, and redirect right back to the same route.
 
-At the bottom, if the request isn’t a post, we just render our `index.html.twig`, which is our remote template. When you have a big
-switch-case statement like this, it’s a good opportunity to refactor, especially as you add more buttons and logic. A great
-refactor for this is to use the command pattern. If you want a more in depth look at this pattern, 
-search for "Command Pattern" on SymfonyCasts. You'll find our full "design patterns" course.
+Finally, at the bottom, if the request *isn’t* a `POST`, we just render `index.html.twig`. That's our remote template. When you have a big switch-case statement like this, this is a good opportunity to refactor, especially as we add more buttons and logic. A great way to do this is with the Command pattern. If you'd like a more in-depth look at this pattern, check out our "Design Patterns" course!
 
-The first thing we’re going to do is create our commands, which will represent the buttons and house all their logic. We’ll
-create a new directory in our `src/` folder to organize our code a bit. We’ll call this `Remote`, and inside, create a
-subfolder called `Button`. Then we’ll create a new PHP class for each button. We’re going to start by creating an interface
-that each button will need to implement so that our command handler can handle these buttons predictably. We’ll call it
-`ButtonInterface`. You can see that PHPStorm automatically creates an interface for us. We’ll add one public method, `press`,
-which will have no arguments and return `void`.
+Okay, the first thing we’re going to do is create some commands, which will represent the buttons and house all of their logic. In `src/`, let's create a new directory to better organize our code. We’ll call it `Remote` and, inside, create another folder called `Button`. Perfect! Next, we need create a new PHP class for each button. We'll start by creating an *interface* that each button will implement so our command handler can *predictably* handle them. We’ll call it `ButtonInterface` and, right here, we can see that PHPStorm will *automatically* create an interface for us. Inside, we’ll say `public function press()`, which will have *no* arguments and return `void`.
 
-For the actual button implementations, I already have them created in the `tutorial/` directory. You can just copy all the
-`PHP` files into this `Button` directory. Each button's `press()` method, has the same `dump()` we saw in our controller. `press` method. 
-For example, the `ChannelDownButton` has the `Change channel down` message.
+In the `tutorial/` directory... look at that! All of the button implementations are here and ready to go! We just need to copy all of the PHP files and add them to the `Button` directory. *Easy peasy*! If we look at `ChannelDownButton.php`, we can see that it has the same `press()` method and `dump()` that we saw in our controller, along with the button message.
 
-We now have our commands, which are the buttons. Next, we need a command handler to take the button
-name and execute the corresponding command. For this, we’ll create an object to act as our command handler. Under
-`Remote`, we’ll create a new class called `ButtonRemote`. I like to mark classes as `final` by default, removing it only if
-extension is needed. This is just a personal preference, so feel free to leave `final` off.
+All right, we have our commands! Now we need a *command handler* to take the button name and execute the corresponding command. For this, we’ll create an *object* to *act* as our command handler. In the `Remote` directory, create a new class called `ButtonRemote`. I prefer to mark classes as `final` by default, removing it only if an extension is needed. This isn't required, so feel free to leave that off.
 
-In this class, we’ll create a public method called `press()`, which will take a string argument `$name`, representing the button
-name. This method has no return so use `void` as the return type. We’ll now create a constructor for this object, which will take a `ContainerInterface`.
-We’ll grab this from `PSR\Container`. This container will store our button objects as a key-value store, with the key
-being the button name and the value being the button object. In the `press()` method, we’ll use `$this->container->get($name)` to
-retrieve the `ButtonInterface` instance and then call `press()`.
+In our new class, create a public method - `press()`. This will take a `string` argument, `$name`, that represents the button name. This method doesn't return anything, so use `void` as the return type. Now we can create a constructor for this object, and inside, add `private ContainerInterface $container`. Make sure you grab the one from `PSR\Container`. This container will store our button objects as key-values - the *key* being the button name and the *value* being the button object. In the `press()` method, we’ll use `$this->container->get($name)` to *retrieve* the `ButtonInterface` instance and call `press()`.
 
-At this point, calling the `press()` method will give us an error because Symfony doesn’t know how to wire up this container.
-To inform Symfony, we’ll use the `AutowireLocator` dependency injection attribute. In older Symfony versions, this was called
-`TaggedLocator`, but it was renamed in Symfony 7.1 to be more consistent with other attributes. The first argument on the
-attribute will be an array with the button names as keys and their corresponding class names as values. Symfony will convert these into the
-actual button instances when building the container.
+Right now, calling the `press()` method will give us an error because Symfony doesn’t know how to wire up this container. To help out, we’ll use the `#[AutowireLocator()]` dependency injection attribute. In *older* Symfony versions, this was called `TaggedLocator`, but it was *renamed* in Symfony 7.1 to be more consistent with other attributes. The first argument on the attribute will be an array with the button names as keys and their corresponding class names as values. Symfony will convert these into the *actual* button instances when building the container.
 
-Let’s go ahead and add all our buttons to this container: `Power`, `ChannelUp`, `ChannelDown`, `VolumeUp`, `VolumeDown`. 
-Our command handler is ready! Now, we need to replace the big switch-case statement in our controller with this.
+Okay, let's add all of our buttons to this container. The first button - `Power` - will look like this: `'power' => PowerButton::class`. The rest of our buttons will look very similar: `'channel-up' => ChannelUpButton::class`, `'channel-down' => ChannelDownButton::class`, `'volume-up' => VolumeUpButton::class`, and `'volume-down' => VolumeDownButton::class`. Ta-da! Our command handler is ready! Now we need to replace the big switch-case statement in our controller with *this*.
 
-Back in the controller, after injecting the `Request`, let’s inject `ButtonRemote`. Since this controller is autowired,
-Symfony will automatically inject this. We’ll copy this code to get the button name, then call `press()` on the
-injected `ButtonRemote` object with the button name. We can now remove the entire switch statement, but we still need to handle
-cases where a button isn’t found. We’ll handle the 404 by wrapping `press()` in a `try-catch` block, catching a
-`NotFoundExceptionInterface`. If `ContainerInterface::get()` doesn’t find a command for the button name,
-it will throw this exception.
+Back in `RemoteController.php`, after injecting the `Request`, let’s inject `ButtonRemote`. Since the controller is *autowired*, Symfony will inject this *automatically*. Down here, copy this line to get the button name and paste it above. Below that, say `$remote->press($button)`. Now we can remove this entire `switch` statement, but we *still* need to address cases where a button *isn’t* found. Copy this line here, delete the switch statement entirely, and wrap this `press()` method in a try-catch block. Move `$remote press($button)` into `try`, and below, this will `catch (NotFoundExceptionInterface)`. Paste our code inside and... done! So if `ContainerInterface::get()` doesn’t find a command for the button name, it will throw this exception. Finally, we can add the `previous` exception to the 404 for better debugging.
 
-We’ll add the caught exception to the 404 for better debugging. Our controller is now much smaller, so let’s test it in
-our app. Press the power button: “Power pressed.” Channel up: “Channel up pressed.” Everything seems to be working. If we
-look into the profiler, we can see the `dump()` message is still there and now comes from the correct button implementation.
+Our controller is *much* smaller now, so let’s test it in our app. If we press the "Power" button... “Power pressed”! If we press the "Channel Up" button... “Channel up pressed”! Everything seems to be working. If we check out the profiler, we can see that the `dump()` message is still there, and now it's coming from the correct button implementation. *Sweet*!
 
-There’s another improvement we can make. Every time we add a new button, we currently need to update the `AutowireLocator` attribute
-in our `ButtonRemote`. This is valid, but a bit cumbersome. In the next chapter, we’ll explore a refactor to remove this requirement. That’s next.
+Okay, this looks great, but there’s *another* improvement we can make. Right now, every time we add a new button, we need to update the `AutowireLocator` attribute in our `ButtonRemote`. This is *fine*, but it's a bit cumbersome.
+
+Next: Let's explore a refactor to *remove* this requirement.


### PR DESCRIPTION
I changed a lot of wording throughout to improve flow or account for things happening on screen that wasn't really being addressed by the text. I also added some code to the script because I feel like it's important, especially for the sake of not having big silent gaps, to talk through what we're typing a bit more.

Kevin: I'm not sure who else needs to review this edit (if anyone), so feel free to pull in another reviewer, or let me know who needs to be tagged in the next one.

And this is just a note for the video portion: There was A LOT of movement on screen that isn't super necessary. Mouse movements in big loops, a lot of pointing to things that were ultimately removed or simplified in the script, scrolling up and down kind of quick when there was no need, etc. Just something to keep in mind for future recordings.